### PR TITLE
Fix evaluation warning by using stdenv.hostPlatform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
                       +++ b/nixos_nspawn/system.txt
                       @@ -1 +1 @@
                       -x86_64-linux
-                      +${final.hostPlatform.system}
+                      +${final.stdenv.hostPlatform.system}
                     '')
                 ];
 


### PR DESCRIPTION
Minor fix so that evaluation warnings aren't printed for every host that imports the `nixos-nspawn` overlay.